### PR TITLE
Minor updates

### DIFF
--- a/Thumbies.module
+++ b/Thumbies.module
@@ -212,7 +212,9 @@ Class Thumbies extends WireData implements Module
             $imagick->readImage($frame);
             $imagick->setImageFormat('jpg');
             $imagick->scaleImage(400,0);
-            $imagick = $imagick->flattenImages();
+            $imagick->setImageBackgroundColor('white');
+            $imagick->setImageAlphaChannel(11);
+            $imagick->mergeImageLayers(Imagick::LAYERMETHOD_FLATTEN);
             $save = $imagick->writeImage($this->fullSavePath);
         }
         catch(Exception $e) {

--- a/Thumbies.module
+++ b/Thumbies.module
@@ -126,7 +126,11 @@ Class Thumbies extends WireData implements Module
         $thumbnail = $this->page->$thumbnailField->getFile($this->sanitizedName);
         
         // then see if it exists in the file structure
-        $this->itMightAlreadyBeHere = $this->wire('config')->paths->files . $this->page->id . '/' . $this->sanitizedName;
+        $pathmod = '';
+        if ($this->wire('config')->pagefileSecure) {
+            $pathmod = $this->wire('config')->pagefileSecurePathPrefix;
+        }
+        $this->itMightAlreadyBeHere = $this->wire('config')->paths->files . $pathmod . $this->page->id . '/' . $this->sanitizedName;
         $this->exists = file_exists($this->itMightAlreadyBeHere);
 
         // if it does not, create the file


### PR DESCRIPTION
@ethanbeyer Thanks for the module. This request allows it to be used when pagefileSecure is set to true, and prevents warnings about the call to the deprecated flattenImages() function.